### PR TITLE
Feature: PR previews

### DIFF
--- a/.github/workflows/pr-preview-build.yml
+++ b/.github/workflows/pr-preview-build.yml
@@ -44,7 +44,7 @@ jobs:
           mv docs/_build/html ./pr/
       
       # Upload the preview as an artifact
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: pr
           path: pr/

--- a/.github/workflows/pr-preview-build.yml
+++ b/.github/workflows/pr-preview-build.yml
@@ -1,0 +1,50 @@
+# This workflow will run on each PR - it will build the project
+# and upload as artifacts for the deploy workflow
+name: Build PR preview
+
+on:
+  # Runs on pull requests targeting the default branch
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+concurrency:
+  group: preview-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-preview:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the branch
+      - name: Checkout
+        uses: actions/checkout@v3
+      
+      # Setup Poetry for dependencies
+      - name: Setup Poetry
+        uses: Gr1N/setup-poetry@v8
+      
+      # Build the site with Poetry
+      - name: Build html
+        run: |
+          cd docs
+          poetry install
+          poetry run make html
+      
+      # Store PR number so that it can be extracted in Deploy
+      - name: Create PR artifact
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/NR
+          mv docs/_build/html ./pr/
+      
+      # Upload the preview as an artifact
+      - uses: actions/upload-artifact@v2
+        with:
+          name: pr
+          path: pr/

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           # Generate key with e.g. 'ssh-keygen -t ed25519 -C "OPA GH Actions Deploy Key" -f gh-pages'
           # deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }} 
-          personal_token: ${{ secrets.PERSONAL_TOKEN }}
+          personal_token: ${{ secrets.PR_DEPLOY_TOKEN }}
           publish_dir: ./html
           external_repository: OpenPodcastAPI/pr-previews
           destination_dir: pr-${{ env.pr }}/

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -13,9 +13,8 @@ concurrency:
   group: preview-${{ github.ref }}
   cancel-in-progress: false
 
-# Sets permissions of the GITHUB_TOKEN to allow writing to the gh-pages branch and writing a pull request comment
+# Sets permissions of the GITHUB_TOKEN to allow writing a pull request comment
 permissions:
-  contents: write
   pull-requests: write
 
 jobs:
@@ -86,4 +85,4 @@ jobs:
             | PR Preview |
             | :---: |
             | :rocket: Deployed preview to https://${{ env.org }}.github.io/${{ env.preview-repo }}/${{ env.preview-folder }} |
-            | on branch [`${{ env.preview-branch }}`](${{ github.server_url }}/${{ github.repository }}/tree/${{ env.preview-branch }}) at ${{ env.datetime }} |
+            | on [`${{ env.preview-repo }}:${{ env.preview-branch }}`](${{ github.server_url }}/${{ env.org }}/${{ env.preview-repo }}/tree/${{ env.preview-branch }}) at ${{ env.datetime }} |

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -25,28 +25,14 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
     steps:
       # Download PR build artifact from last run
-      # Taken from: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
-      - name: 'Download artifact'
-        uses: actions/github-script@v3.1.0
-        with:
-          script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: ${{github.event.workflow_run.id }},
-            });
-            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "pr"
-            })[0];
-            var download = await github.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip',
-            });
-            var fs = require('fs');
-            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
-      
+      - name: Download artifact
+        id: download-artifact
+        uses: dawidd6/action-download-artifact@v2
+        with: 
+          run_id: ${{github.event.workflow_run.id }}
+          name: pr
+          skip_unpack: true
+          
       # Extract artifact, get PR number and store it in env
       - name: Extract artifact and PR number
         run: |
@@ -85,4 +71,4 @@ jobs:
             | PR Preview |
             | :---: |
             | :rocket: Deployed preview to https://${{ env.org }}.github.io/${{ env.preview-repo }}/${{ env.preview-folder }} |
-            | on [`${{ env.preview-repo }}:${{ env.preview-branch }}`](${{ github.server_url }}/${{ env.org }}/${{ env.preview-repo }}/tree/${{ env.preview-branch }}) at ${{ env.datetime }} |
+            | on [`${{ env.preview-repo }}`](${{ github.server_url }}/${{ env.org }}/${{ env.preview-repo }}/tree/${{ env.preview-branch }}/pr-${{ env.pr }}) at ${{ env.datetime }} |

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -58,9 +58,10 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           # Generate key with e.g. 'ssh-keygen -t ed25519 -C "OPA GH Actions Deploy Key" -f gh-pages'
-          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }} 
+          # deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }} 
+          personal_token: ${{ secrets.PERSONAL_TOKEN }}
           publish_dir: ./html
-          external_repository: OpenPodcastAPI/pr-preview
+          external_repository: OpenPodcastAPI/pr-previews
           destination_dir: pr-${{ env.pr }}/
           keep_files: true
         
@@ -74,7 +75,7 @@ jobs:
 
       - name: Create PR comment
         env:
-          preview-repo: 'pr-preview'
+          preview-repo: 'pr-previews'
           preview-branch: 'gh-pages'
           preview-folder: 'pr-${{ env.pr }}'
         uses: marocchino/sticky-pull-request-comment@v2

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -1,0 +1,88 @@
+# PR deployment splitted into two actions so that PRs of forks can be previewed as well
+# This workflow will be started on each PR, but it will run on branch "main", so that
+# it has the necessary rights to access repository secrets
+name: Deploy PR preview
+
+on:
+  workflow_run:
+    workflows: ["Build PR preview"]
+    types:
+      - completed
+
+concurrency:
+  group: preview-${{ github.ref }}
+  cancel-in-progress: false
+
+# Sets permissions of the GITHUB_TOKEN to allow writing to the gh-pages branch and writing a pull request comment
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      # Download PR build artifact from last run
+      # Taken from: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+      - name: 'Download artifact'
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+      
+      # Extract artifact, get PR number and store it in env
+      - name: Extract artifact and PR number
+        run: |
+          unzip pr.zip
+          echo "pr=$(cat ./NR)" >> $GITHUB_ENV
+      
+      - name: Deploy preview          
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          # Generate key with e.g. 'ssh-keygen -t ed25519 -C "OPA GH Actions Deploy Key" -f gh-pages'
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }} 
+          publish_dir: ./html
+          external_repository: OpenPodcastAPI/pr-preview
+          destination_dir: pr-${{ env.pr }}/
+          keep_files: true
+        
+      # With inspiration from https://github.com/rossjrw/pr-preview-action
+      - name: Get Pages URL and datetime
+        run: |
+          org=$(echo "$GITHUB_REPOSITORY" | cut -d "/" -f 1)
+          echo "org=$org" >> $GITHUB_ENV
+          echo "datetime=$(date '+%Y-%m-%d %H:%M %Z')" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Create PR comment
+        env:
+          preview-repo: 'pr-preview'
+          preview-branch: 'gh-pages'
+          preview-folder: 'pr-${{ env.pr }}'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-preview
+          number: ${{ env.pr }}
+          message: |
+            | PR Preview |
+            | :---: |
+            | :rocket: Deployed preview to https://${{ env.org }}.github.io/${{ env.preview-repo }}/${{ env.preview-folder }} |
+            | on branch [`${{ env.preview-branch }}`](${{ github.server_url }}/${{ github.repository }}/tree/${{ env.preview-branch }}) at ${{ env.datetime }} |


### PR DESCRIPTION
How these workflows work:

#### `pr-preview-build.yml`
- Is executed on each PR change, runs on the PR itself
- Builds the project, uploads as an artifact

#### `pr-preview-deploy.yml`
- Is executed after each run of `pr-preview-build.yml`
- Runs on the `main` branch, so has the necessary permissions to deploy to Pages
- Fetches the uploaded artifact, deploys it to `OpenPodcastAPI/pr-preview`
- Afterwards, pushes a comment to the PR containing a link to the generated preview

##### Why this needs to be separated into two workflows:
When a PR is opened from a fork of `api-specs`, the workflow also runs on the PR itself, that means in the forked repository. This repo has no permissions to access the secrets of `OPA/api-specs`, which are needed for deployment to GH pages. So it needed to be split, so that the deployment is executed on `main`.

##### Secrets needed
The latter workflow needs permissions to write to `OpenPodcastAPI/pr-preview`. This can be achieved by either a GitHub Application Token or a private/public key comb.
- GitHub Application Token: Allows more specific permission granting, but needs an expiration date => we will need to renew it someday (not much work)
- Public/private key: Allows only full control over the `pr-preview` repo, but does not necessarily expire

(both documented [in the action used](https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-deploy-to-external-repository-external_repository))

**Application tokens** can be created under: User settings > Developer settings > Personal access tokens > Fine-grained tokens. We'll only need access to the `pr-preview` repo and only `read-and-write` access for the `Contents` permission.

**Private/public keys** can be generated locally, e.g. with the command `ssh-keygen -t ed25519 -C "OPA GH Actions Deploy Key" -f gh-pages`. The public key needs to be added to Repo settings > Deploy keys (`pr-preview`) and the public key needs to be added to Repo settings > Secrets and variables > Actions (`api-specs`).

The current configuration expects a private/public key comb, but I can change this quickly.

Edit: I think I prefer deploy keys (since they can be better narrowed down) over ssh keys. Will change this soon.

Fixes #28 
