### PR TITLE
Improve Renovate behavior

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,17 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  "rangeStrategy": "bump",
+  "packageRules": [
+    {
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ],
+      "automerge": true
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,12 @@
         "digest"
       ],
       "automerge": true
+    },
+    {
+      "matchPackagePatterns": [
+        "*astro*"
+      ],
+      "groupName": "Astro"
     }
   ]
 }


### PR DESCRIPTION
Renovate is currently only bumping versions in the package lock file. It should also be bumping the versions in the package.json just for consistency. 

This change introduces:

- [x] The ability to automerge small updates so we don't keep having to do this manually.
- [x] Bundled updates for Astro dependencies to minimize the number of pull requests.