### PR TITLE
New capabilities endpoint spec

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -46,6 +46,13 @@ export default defineConfig({
               link: "specs",
             },
             {
+              label: "Capabilities",
+              collapsed: true,
+              autogenerate: {
+                directory: "specs/capabilities",
+              },
+            },
+            {
               label: "Subscriptions",
               collapsed: true,
               autogenerate: {

--- a/schema.yml
+++ b/schema.yml
@@ -22,31 +22,34 @@ paths:
             type: string
             format: date-time
           required: false
-          example: "2022-04-23T18:25:43.511Z"
+          example:
+            '2022-04-23T18:25:43.511Z'
         - in: query
           name: page
           schema:
             type: number
           required: false
-          example: 1
+          example:
+            1
         - in: query
           name: per_page
           schema:
             type: number
           required: false
-          example: 5
+          example:
+            5
       responses:
-        "200":
+        '200':
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Subscriptions"
+                $ref: '#/components/schemas/Subscriptions'
             application/xml:
               schema:
-                $ref: "#/components/schemas/Subscriptions"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
+                $ref: '#/components/schemas/Subscriptions'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
       security:
         - podcast_auth:
             - read:subscriptions
@@ -57,21 +60,21 @@ paths:
       description: Add one or more new subscriptions for the authenticated user by passing an array of feed URLs in the request body
       operationId: addSubscription
       requestBody:
-        $ref: "#/components/requestBodies/FeedArray"
+        $ref: '#/components/requestBodies/FeedArray'
       responses:
-        "200":
+        '200':
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/NewSubscriptions"
+                $ref: '#/components/schemas/NewSubscriptions'
             application/xml:
               schema:
-                $ref: "#/components/schemas/NewSubscriptions"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "405":
-          $ref: "#/components/responses/ValidationException"
+                $ref: '#/components/schemas/NewSubscriptions'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '405':
+          $ref: '#/components/responses/ValidationException'
       security:
         - podcast_auth:
             - write:subscriptions
@@ -91,23 +94,23 @@ paths:
           required: true
           example: 968cb508-803c-493c-8ff2-9e397dadb83c
       responses:
-        "200":
+        '200':
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Subscription"
+                $ref: '#/components/schemas/Subscription'
             application/xml:
               schema:
-                $ref: "#/components/schemas/Subscription"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "405":
-          $ref: "#/components/responses/ValidationException"
-        "410":
-          $ref: "#/components/responses/Gone"
+                $ref: '#/components/schemas/Subscription'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '405':
+          $ref: '#/components/responses/ValidationException'
+        '410':
+          $ref: '#/components/responses/Gone'
       security:
         - podcast_auth:
             - read:subscriptions
@@ -126,23 +129,23 @@ paths:
           required: true
           example: 968cb508-803c-493c-8ff2-9e397dadb83c
       requestBody:
-        $ref: "#/components/requestBodies/PatchedSubscription"
+        $ref: '#/components/requestBodies/PatchedSubscription'
       responses:
-        "200":
+        '200':
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PatchedSubscription"
+                $ref: '#/components/schemas/PatchedSubscription'
             application/xml:
               schema:
-                $ref: "#/components/schemas/PatchedSubscription"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "405":
-          $ref: "#/components/responses/ValidationException"
+                $ref: '#/components/schemas/PatchedSubscription'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '405':
+          $ref: '#/components/responses/ValidationException'
       security:
         - podcast_auth:
             - write:subscriptions
@@ -161,14 +164,14 @@ paths:
           required: true
           example: 2d8bb39b-8d34-48d4-b223-a0d01eb27d71
       responses:
-        "202":
-          $ref: "#/components/responses/DeletionReceived"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "405":
-          $ref: "#/components/responses/ValidationException"
+        '202':
+          $ref: '#/components/responses/DeletionReceived'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '405':
+          $ref: '#/components/responses/ValidationException'
       security:
         - podcast_auth:
             - write:subscriptions
@@ -188,14 +191,14 @@ paths:
           required: true
           example: 25
       responses:
-        "200":
-          $ref: "#/components/responses/DeletionResponse"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "405":
-          $ref: "#/components/responses/ValidationException"
+        '200':
+          $ref: '#/components/responses/DeletionResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '405':
+          $ref: '#/components/responses/ValidationException'
       security:
         - podcast_auth:
             - read:subscriptions
@@ -220,13 +223,13 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: '#/components/schemas/Error'
           example:
             code: 401
             message: User not authorized
         application/xml:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: '#/components/schemas/Error'
           example:
             code: 401
             message: User not authorized
@@ -235,13 +238,13 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: '#/components/schemas/Error'
           example:
             code: 404
             message: Resource not found
         application/xml:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: '#/components/schemas/Error'
           example:
             code: 404
             message: Resource not found
@@ -250,13 +253,13 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: '#/components/schemas/Error'
           example:
             code: 405
             message: Input could not be validated
         application/xml:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: '#/components/schemas/Error'
           example:
             code: 405
             message: Input could not be validated
@@ -265,13 +268,13 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: '#/components/schemas/Error'
           example:
             code: 410
             message: Subscription has been deleted
         application/xml:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: '#/components/schemas/Error'
           example:
             code: 410
             message: Subscription has been deleted
@@ -280,13 +283,13 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Success"
+            $ref: '#/components/schemas/Success'
           example:
             deletion_id: 25
             message: Deletion request was received and will be processed
         application/xml:
           schema:
-            $ref: "#/components/schemas/Success"
+            $ref: '#/components/schemas/Success'
           example:
             deletion_id: 25
             message: Deletion request was received and will be processed
@@ -295,7 +298,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Deletion"
+            $ref: '#/components/schemas/Deletion'
           examples:
             Success:
               value:
@@ -314,7 +317,7 @@ components:
                 message: The deletion process encountered an error and was rolled backwas rolled back
         application/xml:
           schema:
-            $ref: "#/components/schemas/Deletion"
+            $ref: '#/components/schemas/Deletion'
           examples:
             Success:
               value:
@@ -445,7 +448,7 @@ components:
         subscriptions:
           type: array
           items:
-            $ref: "#/components/schemas/Subscription"
+            $ref: '#/components/schemas/Subscription'
       example:
         total: 2
         page: 1
@@ -469,11 +472,11 @@ components:
         success:
           type: array
           items:
-            $ref: "#/components/schemas/NewSubscription"
+            $ref: '#/components/schemas/NewSubscription'
         failure:
           type: array
           items:
-            $ref: "#/components/schemas/FailedSubscription"
+            $ref: '#/components/schemas/FailedSubscription'
       example:
         success:
           - feed_url: https://example.com/rss1
@@ -609,42 +612,42 @@ components:
             urn:opa:core:
               "0.0.1":
                 status: DEPRECATED
-                root: "/api/v0"
+                root: '/v0'
               "1.0.0":
                 status: STABLE
-                root: "/api/v1"
+                root: '/v1'
               "2.0.0":
                 status: UNSTABLE
-                root: "/api/v2"
+                root: '/v2'
             urn:opa:extra:playcount:
               "0.0.1":
                 status: DEPRECATED
-                root: "/api/v0/playcount"
+                root: '/v0/playcount'
               "1.0.0":
                 status: STABLE
-                root: "/api/v1/playcount"
+                root: '/v1/playcount'
               "2.0.0":
                 status: UNSTABLE
-                root: "/api/v2/playcount"
+                root: '/v2/playcount'
   requestBodies:
     FeedArray:
       description: An array of feeds the user wants to subscribe to
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/FeedArray"
+            $ref: '#/components/schemas/FeedArray'
         application/xml:
           schema:
-            $ref: "#/components/schemas/FeedArray"
+            $ref: '#/components/schemas/FeedArray'
     PatchedSubscription:
       description: A request containing new information to update an existing subscription with
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/SubscriptionUpdate"
+            $ref: '#/components/schemas/SubscriptionUpdate'
         application/xml:
           schema:
-            $ref: "#/components/schemas/SubscriptionUpdate"
+            $ref: '#/components/schemas/SubscriptionUpdate'
   securitySchemes:
     podcast_auth:
       type: oauth2

--- a/schema.yml
+++ b/schema.yml
@@ -22,34 +22,31 @@ paths:
             type: string
             format: date-time
           required: false
-          example:
-            '2022-04-23T18:25:43.511Z'
+          example: "2022-04-23T18:25:43.511Z"
         - in: query
           name: page
           schema:
             type: number
           required: false
-          example:
-            1
+          example: 1
         - in: query
           name: per_page
           schema:
             type: number
           required: false
-          example:
-            5
+          example: 5
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Subscriptions'
+                $ref: "#/components/schemas/Subscriptions"
             application/xml:
               schema:
-                $ref: '#/components/schemas/Subscriptions'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
+                $ref: "#/components/schemas/Subscriptions"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
       security:
         - podcast_auth:
             - read:subscriptions
@@ -60,21 +57,21 @@ paths:
       description: Add one or more new subscriptions for the authenticated user by passing an array of feed URLs in the request body
       operationId: addSubscription
       requestBody:
-        $ref: '#/components/requestBodies/FeedArray'
+        $ref: "#/components/requestBodies/FeedArray"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NewSubscriptions'
+                $ref: "#/components/schemas/NewSubscriptions"
             application/xml:
               schema:
-                $ref: '#/components/schemas/NewSubscriptions'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '405':
-          $ref: '#/components/responses/ValidationException'
+                $ref: "#/components/schemas/NewSubscriptions"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "405":
+          $ref: "#/components/responses/ValidationException"
       security:
         - podcast_auth:
             - write:subscriptions
@@ -94,23 +91,23 @@ paths:
           required: true
           example: 968cb508-803c-493c-8ff2-9e397dadb83c
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Subscription'
+                $ref: "#/components/schemas/Subscription"
             application/xml:
               schema:
-                $ref: '#/components/schemas/Subscription'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '405':
-          $ref: '#/components/responses/ValidationException'
-        '410':
-          $ref: '#/components/responses/Gone'
+                $ref: "#/components/schemas/Subscription"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "405":
+          $ref: "#/components/responses/ValidationException"
+        "410":
+          $ref: "#/components/responses/Gone"
       security:
         - podcast_auth:
             - read:subscriptions
@@ -129,23 +126,23 @@ paths:
           required: true
           example: 968cb508-803c-493c-8ff2-9e397dadb83c
       requestBody:
-        $ref: '#/components/requestBodies/PatchedSubscription'
+        $ref: "#/components/requestBodies/PatchedSubscription"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PatchedSubscription'
+                $ref: "#/components/schemas/PatchedSubscription"
             application/xml:
               schema:
-                $ref: '#/components/schemas/PatchedSubscription'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '405':
-          $ref: '#/components/responses/ValidationException'
+                $ref: "#/components/schemas/PatchedSubscription"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "405":
+          $ref: "#/components/responses/ValidationException"
       security:
         - podcast_auth:
             - write:subscriptions
@@ -164,14 +161,14 @@ paths:
           required: true
           example: 2d8bb39b-8d34-48d4-b223-a0d01eb27d71
       responses:
-        '202':
-          $ref: '#/components/responses/DeletionReceived'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '405':
-          $ref: '#/components/responses/ValidationException'
+        "202":
+          $ref: "#/components/responses/DeletionReceived"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "405":
+          $ref: "#/components/responses/ValidationException"
       security:
         - podcast_auth:
             - write:subscriptions
@@ -191,14 +188,14 @@ paths:
           required: true
           example: 25
       responses:
-        '200':
-          $ref: '#/components/responses/DeletionResponse'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '405':
-          $ref: '#/components/responses/ValidationException'
+        "200":
+          $ref: "#/components/responses/DeletionResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "405":
+          $ref: "#/components/responses/ValidationException"
       security:
         - podcast_auth:
             - read:subscriptions
@@ -223,13 +220,13 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Error'
+            $ref: "#/components/schemas/Error"
           example:
             code: 401
             message: User not authorized
         application/xml:
           schema:
-            $ref: '#/components/schemas/Error'
+            $ref: "#/components/schemas/Error"
           example:
             code: 401
             message: User not authorized
@@ -238,13 +235,13 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Error'
+            $ref: "#/components/schemas/Error"
           example:
             code: 404
             message: Resource not found
         application/xml:
           schema:
-            $ref: '#/components/schemas/Error'
+            $ref: "#/components/schemas/Error"
           example:
             code: 404
             message: Resource not found
@@ -253,13 +250,13 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Error'
+            $ref: "#/components/schemas/Error"
           example:
             code: 405
             message: Input could not be validated
         application/xml:
           schema:
-            $ref: '#/components/schemas/Error'
+            $ref: "#/components/schemas/Error"
           example:
             code: 405
             message: Input could not be validated
@@ -268,13 +265,13 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Error'
+            $ref: "#/components/schemas/Error"
           example:
             code: 410
             message: Subscription has been deleted
         application/xml:
           schema:
-            $ref: '#/components/schemas/Error'
+            $ref: "#/components/schemas/Error"
           example:
             code: 410
             message: Subscription has been deleted
@@ -283,13 +280,13 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Success'
+            $ref: "#/components/schemas/Success"
           example:
             deletion_id: 25
             message: Deletion request was received and will be processed
         application/xml:
           schema:
-            $ref: '#/components/schemas/Success'
+            $ref: "#/components/schemas/Success"
           example:
             deletion_id: 25
             message: Deletion request was received and will be processed
@@ -298,7 +295,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Deletion'
+            $ref: "#/components/schemas/Deletion"
           examples:
             Success:
               value:
@@ -317,7 +314,7 @@ components:
                 message: The deletion process encountered an error and was rolled backwas rolled back
         application/xml:
           schema:
-            $ref: '#/components/schemas/Deletion'
+            $ref: "#/components/schemas/Deletion"
           examples:
             Success:
               value:
@@ -448,7 +445,7 @@ components:
         subscriptions:
           type: array
           items:
-            $ref: '#/components/schemas/Subscription'
+            $ref: "#/components/schemas/Subscription"
       example:
         total: 2
         page: 1
@@ -472,11 +469,11 @@ components:
         success:
           type: array
           items:
-            $ref: '#/components/schemas/NewSubscription'
+            $ref: "#/components/schemas/NewSubscription"
         failure:
           type: array
           items:
-            $ref: '#/components/schemas/FailedSubscription'
+            $ref: "#/components/schemas/FailedSubscription"
       example:
         success:
           - feed_url: https://example.com/rss1
@@ -601,44 +598,53 @@ components:
               type: object
               required:
                 - status
+                - root
               properties:
                 status:
                   type: string
                   enum: [STABLE, UNSTABLE, DEPRECATED]
+                root:
+                  type: string
           example:
             urn:opa:core:
-              "0.1.0":
-                status: STABLE
-              "1.0.0":
-                status: UNSTABLE
               "0.0.1":
                 status: DEPRECATED
+                root: "/api/v0"
+              "1.0.0":
+                status: STABLE
+                root: "/api/v1"
+              "2.0.0":
+                status: UNSTABLE
+                root: "/api/v2"
             urn:opa:extra:playcount:
-              "0.1.0":
-                status: STABLE
-              "1.0.0":
-                status: UNSTABLE
               "0.0.1":
                 status: DEPRECATED
+                root: "/api/v0/playcount"
+              "1.0.0":
+                status: STABLE
+                root: "/api/v1/playcount"
+              "2.0.0":
+                status: UNSTABLE
+                root: "/api/v2/playcount"
   requestBodies:
     FeedArray:
       description: An array of feeds the user wants to subscribe to
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/FeedArray'
+            $ref: "#/components/schemas/FeedArray"
         application/xml:
           schema:
-            $ref: '#/components/schemas/FeedArray'
+            $ref: "#/components/schemas/FeedArray"
     PatchedSubscription:
       description: A request containing new information to update an existing subscription with
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/SubscriptionUpdate'
+            $ref: "#/components/schemas/SubscriptionUpdate"
         application/xml:
           schema:
-            $ref: '#/components/schemas/SubscriptionUpdate'
+            $ref: "#/components/schemas/SubscriptionUpdate"
   securitySchemes:
     podcast_auth:
       type: oauth2

--- a/schema.yml
+++ b/schema.yml
@@ -202,6 +202,20 @@ paths:
       security:
         - podcast_auth:
             - read:subscriptions
+  /capabilities:
+    get:
+      tags:
+        - Capabilities
+      summary: Retrieve server capabilities
+      description: Returns a summary of features and core specification versions supported by the server.
+      operationId: getCapabilities
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Capabilities"
 components:
   responses:
     Unauthorized:
@@ -573,6 +587,39 @@ components:
         deletion_id: 25
         status: SUCCESS
         message: Subscription deleted successfully
+    Capabilities:
+      type: object
+      properties:
+        capabilities:
+          type: object
+          description: |
+            The features supported by the server. The first object MUST be "urn:opa:core".
+          additionalProperties:
+            type: object
+            description: A map of versions for a specific feature.
+            additionalProperties:
+              type: object
+              required:
+                - status
+              properties:
+                status:
+                  type: string
+                  enum: [STABLE, UNSTABLE, DEPRECATED]
+          example:
+            urn:opa:core:
+              "0.1.0":
+                status: STABLE
+              "1.0.0":
+                status: UNSTABLE
+              "0.0.1":
+                status: DEPRECATED
+            urn:opa:extra:playcount:
+              "0.1.0":
+                status: STABLE
+              "1.0.0":
+                status: UNSTABLE
+              "0.0.1":
+                status: DEPRECATED
   requestBodies:
     FeedArray:
       description: An array of feeds the user wants to subscribe to

--- a/src/content/docs/specs/capabilities/get-capabilities.mdx
+++ b/src/content/docs/specs/capabilities/get-capabilities.mdx
@@ -1,0 +1,53 @@
+---
+title: Get capabilities
+description: An endpoint for querying server capabilities
+next: false
+sidebar:
+  order: 2
+---
+
+import CoreAction from "@partials/_core-action.mdx";
+
+<CoreAction />
+
+```http title="Endpoint"
+GET /v1/capabilities
+```
+
+The capabilities endpoint exposes details about the features a server supports. Capabilities are scoped by `urn` and MUST contain the following:
+
+- Each supported version of the feature.
+- The `status` of the feature version: `STABLE` | `UNSTABLE` | `DEPRECATED`.
+
+Each `capabilities` response MUST contain a `urn:opa:core` object that lists the versions of the Open Podcast API the server supports. Additional capabilities MAY be returned as separate `urn` objects with supported versions.
+
+## Example 200 response
+
+```json
+{
+  "capabilities": {
+    "urn:opa:core": {
+      "0.1.0": {
+        "status": "STABLE"
+      },
+      "1.0.0": {
+        "status": "UNSTABLE"
+      },
+      "0.0.1": {
+        "status": "DEPRECATED"
+      }
+    },
+    "urn:opa:extra:playcount": {
+      "0.1.0": {
+        "status": "STABLE"
+      },
+      "1.0.0": {
+        "status": "UNSTABLE"
+      },
+      "0.0.1": {
+        "status": "DEPRECATED"
+      }
+    }
+  }
+}
+```

--- a/src/content/docs/specs/capabilities/get-capabilities.mdx
+++ b/src/content/docs/specs/capabilities/get-capabilities.mdx
@@ -29,29 +29,29 @@ Each `capabilities` response MUST contain a `urn:opa:core` object that lists the
   "urn:opa:core": {
     "0.0.1": {
       "status": "DEPRECATED",
-      "root": "/api/v0"
+      "root": "/v0"
     },
     "1.0.0": {
       "status": "STABLE",
-      "root": "/api/v1"
+      "root": "/v1"
     },
     "2.0.0": {
       "status": "UNSTABLE",
-      "root": "/api/v2"
+      "root": "/v2"
     }
   },
   "urn:opa:extra:playcount": {
     "0.0.1": {
       "status": "DEPRECATED",
-      "root": "/api/v0/playcount"
+      "root": "/v0/playcount"
     },
     "1.0.0": {
       "status": "STABLE",
-      "root": "/api/v1/playcount"
+      "root": "/v1/playcount"
     },
     "2.0.0": {
       "status": "UNSTABLE",
-      "root": "/api/v2/playcount"
+      "root": "/v2/playcount"
     }
   }
 }

--- a/src/content/docs/specs/capabilities/get-capabilities.mdx
+++ b/src/content/docs/specs/capabilities/get-capabilities.mdx
@@ -18,6 +18,7 @@ The capabilities endpoint exposes details about the features a server supports. 
 
 - Each supported version of the feature.
 - The `status` of the feature version: `STABLE` | `UNSTABLE` | `DEPRECATED`.
+- The `root` relative URL the feature can be accessed at.
 
 Each `capabilities` response MUST contain a `urn:opa:core` object that lists the versions of the Open Podcast API the server supports. Additional capabilities MAY be returned as separate `urn` objects with supported versions.
 
@@ -25,28 +26,32 @@ Each `capabilities` response MUST contain a `urn:opa:core` object that lists the
 
 ```json
 {
-  "capabilities": {
-    "urn:opa:core": {
-      "0.1.0": {
-        "status": "STABLE"
-      },
-      "1.0.0": {
-        "status": "UNSTABLE"
-      },
-      "0.0.1": {
-        "status": "DEPRECATED"
-      }
+  "urn:opa:core": {
+    "0.0.1": {
+      "status": "DEPRECATED",
+      "root": "/api/v0"
     },
-    "urn:opa:extra:playcount": {
-      "0.1.0": {
-        "status": "STABLE"
-      },
-      "1.0.0": {
-        "status": "UNSTABLE"
-      },
-      "0.0.1": {
-        "status": "DEPRECATED"
-      }
+    "1.0.0": {
+      "status": "STABLE",
+      "root": "/api/v1"
+    },
+    "2.0.0": {
+      "status": "UNSTABLE",
+      "root": "/api/v2"
+    }
+  },
+  "urn:opa:extra:playcount": {
+    "0.0.1": {
+      "status": "DEPRECATED",
+      "root": "/api/v0/playcount"
+    },
+    "1.0.0": {
+      "status": "STABLE",
+      "root": "/api/v1/playcount"
+    },
+    "2.0.0": {
+      "status": "UNSTABLE",
+      "root": "/api/v2/playcount"
     }
   }
 }

--- a/src/content/docs/specs/capabilities/index.mdx
+++ b/src/content/docs/specs/capabilities/index.mdx
@@ -1,0 +1,29 @@
+---
+title: Capabilities endpoint
+description: An endpoint for querying server capabilities
+prev: false
+sidebar:
+  label: Overview
+  order: 1
+---
+
+import CoreEndpoint from "@partials/_core-endpoint.mdx";
+
+<CoreEndpoint />
+
+The Open Podcast API is subject to change over time. To ensure backwards compatibility and effective communication of server capabilities, the API specification MUST be versioned in a consistent way.
+
+The specification follows the [Semantic versioning model](https://semver.org/). Each version of the specification MUST adhere to the following rules:
+
+**Major** versions
+: A major version update indicates that a breaking change has occurred. This is reserved for the deprecation, addition, or renaming of **core** capabilities.
+
+**Minor** versions
+: A minor version update indicates that a new **optional** feature has been added or that a **core** feature has received a non-breaking change. This can include the deprecation or addition of parameters or behaviors.
+
+**Patch** versions
+: A patch version update indicates that a small non-breaking change has been made to clarify a feature or address an issue with wording.
+
+## Backwards compatibility
+
+To maintain backwards compatibility between **minor** versions, no parameters nor endpoints may be removed without a **major** version change. Fields may be deprecated in favor of new behaviors, but when queried by an older client the server MUST respond with a compatible response.


### PR DESCRIPTION
Following discussions with @keunes and lots of RFC reading, I've put together an updated and simplified approach for exposing server capabilities to clients.

This spec largely follows the examples set out by the [JMAP RFC](https://datatracker.ietf.org/doc/html/rfc8620). It enables us to easily communicate:

1. What features does the server support?
2. What versions of those features does the server support?
3. What status is the supported feature in?

The latter enables us to help client developers choose whether to expose functionality to users. For example, users might opt in to using `UNSTABLE` features, or they may not. If the server exposes this information, the client can easily choose the feature based on this field.

The `status` field is currently the only field that is exposed, but this can be extended in future if more metadata needs to be revealed for different features. The specification should only require the `status` field to prevent backwards incompatibility.

All features should be scoped to a URN. This enables us to separated the **core** features of OPA (`urn:opa:core`) and any  extra features such as `urn:opa:extra:playcount`.  External features can be scoped to their own namespace and added accordingly.